### PR TITLE
Automation helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ By default `automator` accepts a list of repositories to act on as a comma-separ
 
 The `--dry-run true` argument will not create pull requests, allowing automation scripts to be safely tested.
 
+###list-stash-repos and list-github-repos
+
+List all repositories visible on the configured repository host. By default, one repository name is printed per line. List output is preceded by a status message which may be suppressed with `--quiet true`, which can be useful for composition with other commands. An alternative delimiter can be specified with `--delimiter`, e.g. `--delimiter ","`.
+
 ###AddFiles
 
 For a given repo, create a branch, add files in a specified directory, commit and create a pull request against the original branch.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ The command  to update Github repos then is `updater --useGithub true --updaterC
 Unfortunately running automator using the bash command has some issues when it comes to strings with
 spaces. Instead is has to be run directly, e.g. `java  -cp wrangler-assembly-0.9.0.jar:bin wrangler.commands.Automator --repos uniform,piped --branch travis_fix --title "Travis fix" --description "Travis fix" --useGithub true --script /path/travis_fix.sh`.
 
+By default `automator` accepts a list of repositories to act on as a comma-separated list supplied to the command line argument `--repos`. If the value `-` is used, `automator` will instead read a list of repositories from standard input, one per line, until the end of input is reached. This makes `automator` composable with other wrangler tools, such as `list-stash-repos`, in order to build automation pipelines.
+
+The `--dry-run true` argument will not create pull requests, allowing automation scripts to be safely tested.
+
 ###AddFiles
 
 For a given repo, create a branch, add files in a specified directory, commit and create a pull request against the original branch.

--- a/src/main/scala/wrangler/commands/ListRepos.scala
+++ b/src/main/scala/wrangler/commands/ListRepos.scala
@@ -21,14 +21,17 @@ import wrangler.api.{Stash, Github}
 import wrangler.commands.args.StashOrGithubArgs
 
 /** Arguments for `ListRepos`.*/
-class ListReposArgs extends StashOrGithubArgs
+class ListReposArgs extends StashOrGithubArgs {
+  var delimiter: String  = "\n"   // Separator for displayed repositories
+  var quiet:     Boolean = false  // Suppress start-up message?
+}
 
 /** List all the repos belonging to the specified stash project or github org.*/
 object ListRepos extends ArgMain[ListReposArgs] {
   def main(args: ListReposArgs): Unit = {
     val result = 
       if (args.useStash) {
-        println("Listing Stash repos")
+        if(!args.quiet) println("Listing Stash repos")
         val stash = args.ostash.get
         val (result, _) = Stash.retryUnauthorized(
           stash.tpassword,
@@ -37,7 +40,7 @@ object ListRepos extends ArgMain[ListReposArgs] {
         
         result
       } else {
-        println("Listing Github repos")
+        if(!args.quiet) println("Listing Github repos")
         val github = args.ogithub.get
         val (result, _) = Github.retryUnauthorized(
           github.tpassword,
@@ -47,7 +50,7 @@ object ListRepos extends ArgMain[ListReposArgs] {
         result
       }
 
-    println(result.fold(_.msg, _.mkString("\n")))
+    println(result.fold(_.msg, _.mkString(args.delimiter)))
 
     //Exit manually since dispatch hangs.
     sys.exit(0)

--- a/version.sbt
+++ b/version.sbt
@@ -12,6 +12,6 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.2.2"
+version in ThisBuild := "1.3.0"
 
 licenses := Seq("Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))


### PR DESCRIPTION
Make commands behave more like other unix command line tools. Helps make them composable.

In particular, it allows the user to specify `--repos -` in order to read a list of repositories from standard input, one per line, i.e. the same format that the `list-*-repos` tools generate, that can be easily grepped etc.