### PR TITLE
Allows version lookup for "foo" to check "foo-core"

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -12,6 +12,6 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.3.0"
+version in ThisBuild := "1.3.1"
 
 licenses := Seq("Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))


### PR DESCRIPTION
For example, there is no `humbug` artifact, but if the updaterConfig file specifies:

    au.com.cba.omnia % humbug % latest

and the target project's sbt config contains:

    val humbugVersion = xxx

then act as if `humbug` was an artifact name, and fetch the latest version of `humbug-core`.