### PR TITLE
Updates "val nameVersion = xxx" in sbt config

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -12,6 +12,6 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.3.2"
+version in ThisBuild := "1.3.3"
 
 licenses := Seq("Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))


### PR DESCRIPTION
When the target's sbt config contains a line like:

    val humbugVersion = "quoted version string"

update the version string to the latest version of the given artifact.

This generalises a previous feature that applies only to "val uniformVersion".
Also fixes bugs in the regex for updating depend.omnia() calls.