### PR TITLE
Fix bug introduced in #29

### DIFF
--- a/src/main/scala/wrangler/api/Automator.scala
+++ b/src/main/scala/wrangler/api/Automator.scala
@@ -127,7 +127,8 @@ object Automator {
     case Specific(a)    => a.right
     case l@Latest(g, n) =>
       artifacts
-        .filter(a => a.group == g && a.name.split('-').head == n)  // match both "foo" and "foo-core" (etc)
+        .filter(a => a.group == g &&
+          (a.name == n || a.name.startsWith(n + "-")))             // match both "foo" and "foo-core" (etc)
         .sortBy(_.name)                                            // sort "foo" before "foo-core" (if both were found)
         .headOption
         .map(a => a.copy(name = n).toGeneric.right)                // rewrite "foo-core" to the actual search name "foo"

--- a/version.sbt
+++ b/version.sbt
@@ -12,6 +12,6 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.3.1"
+version in ThisBuild := "1.3.2"
 
 licenses := Seq("Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))


### PR DESCRIPTION
Even after configuring the right artifactory repos, the `omnia-env` dependency could still not be found, due to a bug in the changed I merged only an hour ago.

The code was splitting the artifact name on hyphens, and only considering the first component.