### PR TITLE
v1.3.4: AIDWS-1548 Uplift to match tooling.etl.g8 for Stash projects

### DIFF
--- a/bin/wrangler.conf.template
+++ b/bin/wrangler.conf.template
@@ -1,40 +1,33 @@
 wrangler {
-travisGitPassword =
-travisArtifactoryPassword =
+  travisGitPassword = 
+  travisArtifactoryPassword = 
 
-github {
-  user     =
-  org      =
-  teamid   =
-  apiUrl   =
-  gitUrl   =
-  password =
-}
+  github {
+    user     = 
+    org      = 
+    teamid   = 
+    apiUrl   = 
+    gitUrl   = 
+    password = 
+  }
 
-stash {
-  user    = 
-  project = 
-  apiUrl  = 
-  gitUrl  = 
-}
+  stash {
+    user      = 
+    project   = 
+    apiUrl    = 
+    gitUrl    = 
+    reviewers = 
+  }
 
-artifactory {
-  url      =
-  repos    =
-  user     =
-  password =
-}
+  artifactory {
+    url      = 
+    repos    = 
+    user     = 
+  }
 
-artifactoryInternal {
-  url      =
-  repos    =
-  user     =
-  password =
-}
-
-teamcity {
-  url     =
-  project = 
-  user    = 
-}
+  teamcity {
+    url      = 
+    project  = 
+    user     = 
+  }
 }

--- a/src/main/scala/wrangler/api/Giter8.scala
+++ b/src/main/scala/wrangler/api/Giter8.scala
@@ -30,7 +30,7 @@ object Giter8 {
 
     for {
       _ <- Util.run(cmd, cwd)
-      _ <- Util.run(List("chmod" , "-x", s"$name/sbt"), cwd) // Set execute permission on sbt script.
+      _ <- Util.run(List("chmod" , "+x", s"$name/sbt"), cwd) // Set execute permission on sbt script.
     } yield s"Created $name"
   }
 }

--- a/src/main/scala/wrangler/commands/CreateProject.scala
+++ b/src/main/scala/wrangler/commands/CreateProject.scala
@@ -211,6 +211,7 @@ object CreateProject extends ArgMain[CreateProjectArgs] {
       //"tardis"                 -> "tardis_version",
       //"omnia-test"             -> "omniatest_version",
       "uniform-core_2.10_0.13" -> "uniform_version",
+      "util-template"          -> "template_version",
       "etl-util"               -> "util_version",
       "etl-plugin"             -> "plugin_version"
     )

--- a/version.sbt
+++ b/version.sbt
@@ -12,6 +12,6 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.3.3"
+version in ThisBuild := "1.3.4"
 
 licenses := Seq("Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))


### PR DESCRIPTION
Fixes #20 and #36 for `./bin/create-etl-stash-project`:

* Use latest Artifactory version for `etl.template` (`util-template` / `template_version`).
* Set execute permission on `sbt` script.
* Fix indentation of `wrangler.conf.template` & remove unused `artifactoryInternal`.

**Help!** Build is failing due to “unresolved dependency: org.scala-sbt#io;0.13.2: not found”. It looks like the pre-1.0 binaries for SBT dependencies are no longer in the public maven repo so this build is failing :-( Any ideas? Can we scrounge a copy from a laptop and manually add it to our Artifactory? Who has permission?